### PR TITLE
Fixed null values in "ssis-execution-dataflow-info" query due to inva…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,9 @@ Available scripts:
 ###v 1.2
 
 * Added "ssis-execution-parameter-values" query
+ 
+###v 1.3
+
+* Fixed null values in "ssis-execution-dataflow-info" query due to invalid CTE join on Message ID, added "duration_minutes" column alias
 
 

--- a/ssis-execution-dataflow-info.sql
+++ b/ssis-execution-dataflow-info.sql
@@ -47,11 +47,11 @@ SELECT
 	b.message_source_name,
 	pre_message_time = b.message_time,
 	post_message_time = e.message_time,
-	DATEDIFF(mi, b.message_time, e.message_time)
+	duration_minutes = DATEDIFF(mi, b.message_time, e.message_time)
 FROM
 	ctePRE b
 LEFT OUTER JOIN
-	ctePOST e ON b.operation_id = e.operation_id AND b.package_name = e.package_name AND b.message_source_id = e.message_source_id AND b.event_message_id=e.event_message_id
+	ctePOST e ON b.operation_id = e.operation_id AND b.package_name = e.package_name AND b.message_source_id = e.message_source_id
 WHERE
 	b.operation_id = @executionIdFilter
 AND


### PR DESCRIPTION
Fixed null values in "ssis-execution-dataflow-info" query due to invalid CTE join on Message ID, added "duration_minutes" column alias.